### PR TITLE
Task 9: Implement card view for search results with toggle buttons

### DIFF
--- a/frontend/src/components/EmployeeListContainer.tsx
+++ b/frontend/src/components/EmployeeListContainer.tsx
@@ -5,9 +5,12 @@ import * as t from "io-ts";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeListItem } from "./EmployeeListItem";
 import { Employee, EmployeeT } from "../models/Employee";
+import { type EmployeeListLayout } from "@/types/EmployeeListLayout";
+import { Grid } from "@mui/material";
 
 export type EmployeesContainerProps = {
   filterText: string;
+  layout: EmployeeListLayout;
 };
 
 const EmployeesT = t.array(EmployeeT);
@@ -25,7 +28,7 @@ const employeesFetcher = async (url: string): Promise<Employee[]> => {
   return decoded.right;
 };
 
-export function EmployeeListContainer({ filterText }: EmployeesContainerProps) {
+export function EmployeeListContainer({ filterText, layout }: EmployeesContainerProps) {
   const encodedFilterText = encodeURIComponent(filterText);
   const { data, error, isLoading } = useSWR<Employee[], Error>(
     `/api/employees?filterText=${encodedFilterText}`,
@@ -37,9 +40,21 @@ export function EmployeeListContainer({ filterText }: EmployeesContainerProps) {
     }
   }, [error, filterText]);
   if (data != null) {
-    return data.map((employee) => (
-      <EmployeeListItem employee={employee} key={employee.id} />
-    ));
+    if (layout === "list") {
+      return data.map((employee) => (
+        <EmployeeListItem employee={employee} key={employee.id} />
+      ));   
+    }
+
+    return (
+      <Grid container spacing={2}>
+        {data.map((employee) => (
+          <Grid key={employee.id} size={{ xs: 6, md: 4 }}>
+            <EmployeeListItem employee={employee} />
+          </Grid>
+        ))}
+      </Grid>
+    );
   }
   if (isLoading) {
     return <p>Loading employees...</p>;

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -36,6 +36,7 @@ export function SearchEmployees() {
       <EmployeeListContainer
         key="employeesContainer"
         filterText={searchKeyword}
+        layout={layout}
       />
     </Paper>
   );

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { Paper, TextField } from "@mui/material";
+import { Paper, TextField, Box, ToggleButtonGroup, ToggleButton } from "@mui/material";
 import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
+import { type EmployeeListLayout } from "@/types/EmployeeListLayout";
 
 export function SearchEmployees() {
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [layout, setLayout] = useState<EmployeeListLayout>("list");
   return (
     <Paper
       sx={{
@@ -20,6 +22,17 @@ export function SearchEmployees() {
         value={searchKeyword}
         onChange={(e) => setSearchKeyword(e.target.value)}
       />
+      <Box display="flex" justifyContent="flex-end">
+        <ToggleButtonGroup
+          value={layout}
+          onChange={(_, value) => setLayout(value as unknown as EmployeeListLayout)}
+          exclusive
+          aria-label="layout"
+        >
+          <ToggleButton value="list">リスト</ToggleButton>
+          <ToggleButton value="card">カード</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
       <EmployeeListContainer
         key="employeesContainer"
         filterText={searchKeyword}

--- a/frontend/src/types/EmployeeListLayout.ts
+++ b/frontend/src/types/EmployeeListLayout.ts
@@ -1,0 +1,1 @@
+export type EmployeeListLayout = "list" | "card";


### PR DESCRIPTION
## 📝 概要

検索結果の従業員一覧にカード形式を追加し、ユーザーがカードとリストの表示形式を自由に切り替えられるようにしました。

## 🔧 変更点

- `EmployeeListLayout.ts`を追加し、`EmployeeListLayout`型を新規追加しました。
  - この型は、検索結果の従業員一覧（リスト）のレイアウトを`list`または`card`の2種類から選択できるようにします。
- `SearchEmployees`コンポーネント内に、レイアウトをカードとリストどちらにするかのステートを持たせ、トグルボタンでスイッチできるようにしました。
- `EmployeeListContainer`コンポーネントの引数を新たに追加し、それによってレイアウトをカード形式にするかリスト形式にするか変更しています。

![image](https://github.com/user-attachments/assets/4932d485-3a01-4969-9aec-5e8cd09282de)


## 💡 アピールポイント

このプロジェクトではMaterial UIをUIフレームワークとして利用しているため、MUIのコンポーネントを活用した実装方法にしました。

## 🤖 生成 AI の利用

- 使用した
- 使用した場合は具体的な内容：
  - Material UIを用いたGridレイアウトの実装方法について o4-mini-high に質問しました。
    - ログ: https://chatgpt.com/share/6843cb06-5878-800b-8f8a-bb0535c7e07a