### PR TITLE
Task 3: Implement page name display in global header

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageTitle="社員詳細">
       {/* Mark EmployeeDetailsContainer as CSR */}
       <Suspense>
         <EmployeeDetailsContainer />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageTitle="社員検索">
       <SearchEmployees />
     </GlobalContainer>
   );

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -2,14 +2,23 @@ import { Container } from "@mui/material";
 import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
+import React from "react";
 
-export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+interface GlobalContainerProps {
+  children?: React.ReactNode;
+  pageTitle?: string;
+}
+
+export function GlobalContainer({ children, pageTitle }: GlobalContainerProps) {
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
+        <GlobalHeader
+          title={"タレントマネジメントシステム"}
+          pageTitle={pageTitle}
+        />
       </header>
 
       <VerticalSpacer height={32} />

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -4,9 +4,12 @@ import Link from "next/link";
 
 export interface GlobalHeaderProps {
   title: string;
+  pageTitle?: string;
 }
 
-export function GlobalHeader({ title }: GlobalHeaderProps) {
+export function GlobalHeader({ title, pageTitle }: GlobalHeaderProps) {
+  const displayTitle = pageTitle ? `${title} - ${pageTitle}` : title;
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -22,7 +25,7 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
           </Link>
           <Link href="/">
             <Typography variant="h6" component="h1" sx={{ flexGrow: 1 }}>
-              {title}
+              {displayTitle}
             </Typography>
           </Link>
         </Toolbar>


### PR DESCRIPTION
<!-- タイトル
● タイトルフォーマット Task <N>: <Title of your change> とします。
● <N> 部分に SpreadSheet 上課題番号を含めてください。
「氏名部分検索」を担当する場合例：
Task 1: Implement partial match search on a name -->

## 📝 概要

課題3 グローバルヘッダへのページ名の表示の実装

## 🔧 変更点
- `GlobalContainer.tsx`: `pageTitle` プロパティを追加し、`GlobalHeader` に渡すように修正
- `GlobalHeader.tsx`: `pageTitle` プロパティを受け取り、タイトルと組み合わせて表示するように修正
- `app/page.tsx`: トップページに `pageTitle="社員検索"` を追加
- `app/employee/[id]/page.tsx`: 社員詳細ページに `pageTitle="社員詳細"` を追加


## 💡 アピールポイント

- **コンポーネントの拡張性**: 既存のコンポーネントを壊すことなく、新機能を追加
- **型安全性**: TypeScript のinterface を活用して、型安全な実装を実現

## 🤖 生成 AI の利用
- 使用した
- 使用した場合は具体的な内容：
使用モデル：Claude Sonnet 4
使用方法：プロジェクト機能を使用。前提条件として本プロダクトのGitHubなどを読み込みを行った。
システムプロンプト：
  ```
  #役割
  貴方はプロのエンジニアです。私は修士1年の就活生で、これからインターンシップに参加します。
  このインターンでは「タレントマネジメントシステム」の開発を行います。
  サポートをお願いします。
  ```
  本課題におけるやりとり：https://www.notion.so/Task-3-Implement-page-name-display-in-global-header-20b5da4525c880b3a22aea585500df99?source=copy_link