### PR TITLE
Task5:Implement add employee

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabase.ts
+++ b/backend-ts/src/employee/EmployeeDatabase.ts
@@ -3,4 +3,5 @@ import { Employee } from "./Employee";
 export interface EmployeeDatabase {
     getEmployee(id: string): Promise<Employee | undefined>
     getEmployees(filterText: string): Promise<Employee[]>
+    createEmployee(employeeData: EmployeeCreationData): Promise<Employee>
 }

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -1,5 +1,8 @@
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee } from "./Employee";
+import { randomUUID } from "crypto";
+
+type EmployeeCreationData = Omit<Employee, 'id'>;
 
 export class EmployeeDatabaseInMemory implements EmployeeDatabase {
   private employees: Map<string, Employee>;
@@ -38,5 +41,16 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
 
     return employees.filter((employee) => employee.name.includes(filterText));
 
+  }
+
+  async createEmployee(employeeData: EmployeeCreationData): Promise<Employee> {
+    const id = randomUUID(); // 一意のIDを生成
+    const newEmployee: Employee = {
+      id: id,
+      ...employeeData, // 受け取ったデータ（名前、年齢、スキル）を展開
+    };
+    this.employees.set(id, newEmployee);
+    console.log("Created new employee:", newEmployee);
+    return newEmployee;
   }
 }

--- a/backend-ts/src/handlers.ts
+++ b/backend-ts/src/handlers.ts
@@ -4,6 +4,23 @@ import { Employee } from './employee/Employee';
 import { EmployeeDatabaseDynamoDB } from './employee/EmployeeDatabaseDynamoDB';
 import { EmployeeDatabase } from './employee/EmployeeDatabase';
 
+const createEmployeeHandler = async (database: EmployeeDatabase, body: string | undefined): Promise<LambdaFunctionURLResult> => {
+    if (body == null) {
+        return { statusCode: 400, body: "Request body is missing." };
+    }
+    try {
+        const employeeData = JSON.parse(body);
+        const createdEmployee = await database.createEmployee(employeeData);
+        return {
+            statusCode: 201,
+            body: JSON.stringify(createdEmployee),
+        };
+    } catch (e) {
+        console.error("Failed to parse request body or create employee.", e);
+        return { statusCode: 400, body: "Invalid request body." };
+    }
+}
+
 const getEmployeeHandler = async (database: EmployeeDatabase, id: string): Promise<LambdaFunctionURLResult> => {
     const employee: Employee | undefined = await database.getEmployee(id);
     if (employee == null) {
@@ -34,17 +51,30 @@ export const handle = async (event: LambdaFunctionURLEvent): Promise<LambdaFunct
         const client = new DynamoDBClient();
         const database = new EmployeeDatabaseDynamoDB(client, tableName);
         // https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/urls-invocation.html
+        const httpMethod = event.requestContext.http.method;
         const path = normalizePath(event.requestContext.http.path);
         const query = event.queryStringParameters;
-        if (path === "/api/employees") {
+        // GET /api/employees
+        if (httpMethod === "GET" && path === "/api/employees") {
             return getEmployeesHandler(database, query?.filterText ?? "");
-        } else if (path.startsWith("/api/employees/")) {
+        }
+
+        // POST /api/employees
+        if (httpMethod === "POST" && path === "/api/employees") {
+            return createEmployeeHandler(database, event.body);
+        }
+        
+        // GET /api/employees/:id
+        if (httpMethod === "GET" && path.startsWith("/api/employees/")) {
             const id = path.substring("/api/employees/".length);
             return getEmployeeHandler(database, id);
-        } else {
-            console.log("Invalid path", path);
-            return { statusCode: 400 };
         }
+
+        // 上のどの条件にも当てはまらなかった場合は、すべて無効なリクエストとして扱う
+        console.log("Invalid path or method", path, httpMethod);
+        return { statusCode: 404, body: "Not Found" };
+
+
     } catch (e) {
         console.error('Internal Server Error', e);
         return {

--- a/backend-ts/src/index.ts
+++ b/backend-ts/src/index.ts
@@ -5,6 +5,8 @@ const app = express();
 const port = process.env.PORT ?? 8080;
 const database = new EmployeeDatabaseInMemory();
 
+app.use(express.json()); 
+
 app.get("/api/employees", async (req: Request, res: Response) => {
     const filterText = req.query.filterText ?? "";
     // req.query is parsed by the qs module.
@@ -39,6 +41,22 @@ app.get("/api/employees/:userId", async (req: Request, res: Response) => {
         res.status(200).send(JSON.stringify(employee));
     } catch (e) {
         console.error(`Failed to load the user ${userId}.`, e);
+        res.status(500).send();
+    }
+});
+
+app.post("/api/employees", async (req: Request, res: Response) => {
+    try {
+        // req.bodyにフロントエンドから送信されたJSONデータが入る
+        const newEmployeeData = req.body;
+
+        // バリデーションをここで行うことも可能（今回は省略）
+
+        const createdEmployee = await database.createEmployee(newEmployeeData);
+        // 成功した場合、ステータスコード201(Created)と作成されたデータを返す
+        res.status(201).send(JSON.stringify(createdEmployee));
+    } catch (e) {
+        console.error(`Failed to create an employee.`, e);
         res.status(500).send();
     }
 });

--- a/frontend/src/app/employee/new/page.tsx
+++ b/frontend/src/app/employee/new/page.tsx
@@ -1,0 +1,12 @@
+import { CreateEmployeeForm } from '@/components/CreateEmployeeForm';
+import { Container } from '@mui/material';
+
+// ページ本体の定義
+export default function CreateEmployeePage() {
+  return (
+    <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+      {/* 以前作成したフォームコンポーネントをここに配置します */}
+      <CreateEmployeeForm />
+    </Container>
+  );
+}

--- a/frontend/src/components/CreateEmployeeForm.tsx
+++ b/frontend/src/components/CreateEmployeeForm.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, Button, TextField, Typography, Paper } from "@mui/material";
+
+export function CreateEmployeeForm() {
+  const [name, setName] = useState("");
+  const [age, setAge] = useState("");
+  const [skills, setSkills] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const employeeData = {
+      name,
+      age: parseInt(age, 10),
+      // スキルはカンマ区切りで入力させ、配列に変換
+      skills: skills.split(",").map(s => s.trim()).filter(s => s),
+    };
+
+    if (!name || isNaN(employeeData.age) || employeeData.age <= 0) {
+      setError("氏名と正しい年齢を入力してください。");
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/employees", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(employeeData),
+      });
+
+      if (response.status === 201) {
+        alert("社員が追加されました！");
+        router.push("/"); // 社員一覧ページ（ルート）にリダイレクト
+        router.refresh(); // サーバーのデータを再取得して一覧を更新
+      } else {
+        const errorData = await response.text();
+        setError(`作成に失敗しました: ${errorData}`);
+      }
+    } catch (e) {
+      setError("通信エラーが発生しました。");
+      console.error(e);
+    }
+  };
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Typography variant="h5" mb={2}>社員の追加</Typography>
+      <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={2}>
+        <TextField
+          label="氏名"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <TextField
+          label="年齢"
+          type="number"
+          value={age}
+          onChange={(e) => setAge(e.target.value)}
+          required
+        />
+        <TextField
+          label="スキル (カンマ区切り)"
+          helperText="例: React, TypeScript, AWS"
+          value={skills}
+          onChange={(e) => setSkills(e.target.value)}
+        />
+        <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+          追加する
+        </Button>
+        {error && <Typography color="error" mt={2}>{error}</Typography>}
+      </Box>
+    </Paper>
+  );
+}

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { Paper, TextField, Box, ToggleButtonGroup, ToggleButton, FormControl, InputLabel, Select, MenuItem,} from "@mui/material";
+import { Paper, TextField, Box, ToggleButtonGroup, ToggleButton, FormControl, InputLabel, Select, MenuItem, Fab, } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import Link from "next/link";
 import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
 import { type EmployeeListLayout } from "@/types/EmployeeListLayout";
@@ -10,56 +12,71 @@ export function SearchEmployees() {
   // 並び替えの条件を管理するstate。初期値は「名前 (昇順)」
   const [sortKey, setSortKey] = useState("name_asc");
   return (
-    <Paper
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 2,
-        flex: 1,
-        p: 2,
-      }}
-    >
-      <TextField
-        placeholder="検索キーワードを入力してください"
-        value={searchKeyword}
-        onChange={(e) => setSearchKeyword(e.target.value)}
-      />
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        {/* 並び替え用ドロップダウンを追加 */}
-        <FormControl sx={{ minWidth: 200 }}>
-          <InputLabel id="sort-select-label">並び替え</InputLabel>
-          <Select
-            labelId="sort-select-label"
-            value={sortKey}
-            label="並び替え"
-            onChange={(e) => setSortKey(e.target.value)}
-            size="small"
-          >
-            <MenuItem value="name_asc">名前 (昇順)</MenuItem>
-            <MenuItem value="name_desc">名前 (降順)</MenuItem>
-            <MenuItem value="age_asc">年齢 (若い順)</MenuItem>
-            <MenuItem value="age_desc">年齢 (高い順)</MenuItem>
-            <MenuItem value="skills_desc">スキルの数 (多い順)</MenuItem>
-            <MenuItem value="skills_asc">スキルの数 (少ない順)</MenuItem>
-          </Select>
-        </FormControl>
+    <>
+      <Paper
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          flex: 1,
+          p: 2,
+        }}
+      >
+        <TextField
+          placeholder="検索キーワードを入力してください"
+          value={searchKeyword}
+          onChange={(e) => setSearchKeyword(e.target.value)}
+        />
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          {/* 並び替え用ドロップダウンを追加 */}
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="sort-select-label">並び替え</InputLabel>
+            <Select
+              labelId="sort-select-label"
+              value={sortKey}
+              label="並び替え"
+              onChange={(e) => setSortKey(e.target.value)}
+              size="small"
+            >
+              <MenuItem value="name_asc">名前 (昇順)</MenuItem>
+              <MenuItem value="name_desc">名前 (降順)</MenuItem>
+              <MenuItem value="age_asc">年齢 (若い順)</MenuItem>
+              <MenuItem value="age_desc">年齢 (高い順)</MenuItem>
+              <MenuItem value="skills_desc">スキルの数 (多い順)</MenuItem>
+              <MenuItem value="skills_asc">スキルの数 (少ない順)</MenuItem>
+            </Select>
+          </FormControl>
 
-        <ToggleButtonGroup
-          value={layout}
-          onChange={(_, value) => setLayout(value as unknown as EmployeeListLayout)}
-          exclusive
-          aria-label="layout"
+          <ToggleButtonGroup
+            value={layout}
+            onChange={(_, value) => setLayout(value as unknown as EmployeeListLayout)}
+            exclusive
+            aria-label="layout"
+          >
+            <ToggleButton value="list">リスト</ToggleButton>
+            <ToggleButton value="card">カード</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        <EmployeeListContainer
+          key="employeesContainer"
+          filterText={searchKeyword}
+          layout={layout}
+          sortKey={sortKey}
+        />
+      </Paper>
+      <Link href="/employee/new" passHref>
+        <Fab
+          color="primary"
+          aria-label="add"
+          sx={{
+            position: 'fixed', // 画面に固定
+            bottom: 32,      // 下から32px
+            right: 32,       // 右から32px
+          }}
         >
-          <ToggleButton value="list">リスト</ToggleButton>
-          <ToggleButton value="card">カード</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
-      <EmployeeListContainer
-        key="employeesContainer"
-        filterText={searchKeyword}
-        layout={layout}
-        sortKey={sortKey}
-      />
-    </Paper>
+          <AddIcon />
+        </Fab>
+      </Link>
+    </>
   );
 }


### PR DESCRIPTION
## 📝 概要

ユーザーがUI上から新しい社員情報を登録できるようにするため、社員追加機能を実装しました。
この対応は、フロントエンドの入力フォーム作成、APIエンドポイントの追加、データベースへの保存処理まで、一気通貫で行っています。

## 🔧 変更点

-   **データベース層**
    -   `EmployeeDatabase`インターフェースに、社員を新規作成するための`createEmployee`メソッドを追加しました。
    -   ローカル開発用の`EmployeeDatabaseInMemory`に`createEmployee`を実装しました（IDは自動生成）。
    -   本番環境用の`EmployeeDatabaseDynamoDB`に、`PutItemCommand`を用いて`createEmployee`を実装しました。

-   **API (バックエンド)層**
    -   ローカル開発用のExpressサーバーに、`POST /api/employees`エンドポイントを追加しました。
    -   本番環境用のAWS Lambdaハンドラを修正し、`POST /api/employees`リクエストを処理できるようにしました。

-   **フロントエンド層**
    -   社員一覧ページ(`SearchEmployees`)に、追加ページへ遷移するためのフローティングアクションボタン(FAB)を右下に設置しました。
    -   社員情報を入力・送信するためのフォームコンポーネント(`CreateEmployeeForm`)を作成しました。
    -   上記フォームを持つ、社員追加用の新規ページ (`/employee/new`) を作成しました。

## 💡 アピールポイント

-   **デュアル環境への対応**
    -   ローカルの開発環境(Express/In-Memory)と本番環境(Lambda/DynamoDB)の両方で機能するように実装しました。これにより、どちらの環境でも一貫した動作確認が可能です。

-   **型安全性の考慮**
    -   `Omit<Employee, 'id'>`を用いて、社員作成時に必要なデータの型`EmployeeCreationData`を定義しました。これにより、システムが自動生成する`id`を含まないデータを安全に扱うことができ、コードの堅牢性と可読性を向上させています。

-   **UI/UX**
    -   社員追加ボタンにはMaterial-UIの`Fab`を採用し、ユーザーがいつでも直感的に追加操作を開始できるよう、画面右下に固定で配置しました。

## 🤖 生成 AI の利用

-   **使用した**
-   **使用した場合は具体的な内容**：
    機能実装の全体的な手順の相談、具体的なコード例の生成、発生したエラーの原因特定とデバッグ、アーキテクチャに関する質問、そしてこのプルリクエストの文章作成にあたり、Googleの生成AI(Gemini)の助言を参考にしました。
  - ログ：https://gemini.google.com/app/cfb65d1e2fa389f1?hl=ja