### PR TITLE
Task5：Fix production deployment and routing for SPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# macOS system files
+.DS_Store

--- a/backend-ts/.gitignore
+++ b/backend-ts/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 
 # Lambda layers
 layers/*
+
+*.zip
+# macOS system files
+.DS_Store

--- a/cdk-ts/.gitignore
+++ b/cdk-ts/.gitignore
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!viewer-request-function.js
 *.d.ts
 node_modules
 

--- a/cdk-ts/lib/viewer-request-function.js
+++ b/cdk-ts/lib/viewer-request-function.js
@@ -1,0 +1,15 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // URIの末尾が「/」の場合、index.htmlを補完する
+    if (uri.endsWith('/')) {
+        request.uri += 'index.html';
+    }
+    // URIに「.」(拡張子)が含まれていない場合、.htmlを補完する
+    else if (!uri.includes('.')) {
+        request.uri += '.html';
+    }
+
+    return request;
+}

--- a/frontend/src/components/CreateEmployeeForm.tsx
+++ b/frontend/src/components/CreateEmployeeForm.tsx
@@ -34,8 +34,8 @@ export function CreateEmployeeForm() {
         },
         body: JSON.stringify(employeeData),
       });
-
-      if (response.status === 201) {
+      console.log("Response object:", response);
+      if (response.ok) {
         alert("社員が追加されました！");
         router.push("/"); // 社員一覧ページ（ルート）にリダイレクト
         router.refresh(); // サーバーのデータを再取得して一覧を更新

--- a/frontend/src/components/CreateEmployeeForm.tsx
+++ b/frontend/src/components/CreateEmployeeForm.tsx
@@ -34,7 +34,6 @@ export function CreateEmployeeForm() {
         },
         body: JSON.stringify(employeeData),
       });
-      console.log("Response object:", response);
       if (response.ok) {
         alert("社員が追加されました！");
         router.push("/"); // 社員一覧ページ（ルート）にリダイレクト

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,9 +3,9 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 import React from "react";
-import { Breadcrumbs, Typography, Link as MuiLink } from "@mui/material";
+// import { Link as MuiLink } from "@mui/material";
 import Link from "next/link";
-import HomeIcon from "@mui/icons-material/Home";
+// import HomeIcon from "@mui/icons-material/Home";
 
 interface BreadcrumbItem {
   label: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "intern2025-talent-management-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "intern2025-talent-management-app",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION

## 📝 概要

前回実装した社員追加機能について、本番環境（AWS）へのデプロイ後に、API通信エラーやページ遷移が正しく機能しない問題が発覚しました。

本プルリクエストは、これらの問題を解決し、本番環境でアプリケーションが完全に動作するようにインフラ構成（AWS CDK）と関連設定を修正するものです。

## 🔧 変更点

-   **インフラ定義 (AWS CDK)**
    -   `app-stack.ts`を修正し、CloudFrontディストリビューションの設定を大幅に見直しました。
        -   Next.jsの静的サイトでクリーンURL（例: `/employee/new`）を解決するため、**CloudFront Function (`viewer-request-function.js`) を導入**し、リクエストURIを動的に書き換えるようにしました。
        -   ページ遷移不具合の根本原因であった`errorResponses`設定を削除しました。
        -   API（Lambda）へのリクエストが正しく通るように、`OriginRequestPolicy`や`authType`, `cors`設定を最終化しました。
    -   `viewer-request-function.js`を**新規作成**しました。これは上記のURI書き換えロジックを実装したCloudFront Functionのソースコードです。

-   **フロントエンド (`frontend`)**
    -   本番環境でのルーティングを正しく機能させるため、`next.config.mjs`やコンポーネント内の`<Link>`タグの`href`属性を、クリーンURLを使う形に統一・修正しました。

-   **その他**
    -   `.gitignore`ファイルを更新し、ビルド成果物やOS固有のファイル（`.DS_Store`）をGitの管理対象から除外し、CloudFront Functionのソースコードは対象に含めるよう修正しました。

## 💡 アピールポイント

-   **静的サイトホスティングの課題解決**
    -   S3+CloudFrontで静的SPA（Single Page Application）をホスティングする際の典型的な課題（サブディレクトリへのクリーンURLでのルーティング）を、**CloudFront Function**を用いて解決しました。これにより、ユーザー体験を損なうことなく、モダンなURL設計を維持できています。

-   **Infrastructure as Code (IaC) によるデバッグと修正**
    -   AWSコンソールでの場当たり的な修正ではなく、インフラの問題をCDKのコードレベルで特定し、修正を行いました。これにより、誰がデプロイしても同じインフラが再現される、堅牢な構成になっています。

-   **根本原因の特定**
    -   当初CORSエラーと見られていた問題が、実際にはCloudFrontの署名認証やルーティング設定に起因することを、ブラウザの開発者ツールやAWSの仕様を元に切り分け、特定しました。

## 🤖 生成 AI の利用

-   **使用した**
-   **使用した場合は具体的な内容**：
    前回PRの機能実装に引き続き、デプロイ時に発生した複数の複雑なエラー（CORS、IAM署名、CloudFrontルーティング）の原因特定とデバッグ、解決策としてのCloudFront Functionを含むAWS CDKコードの生成、そしてこのプルリクエストの文章作成にあたり、Googleの生成AI(Gemini)と対話形式で協業しました。
ログ：https://gemini.google.com/app/cfb65d1e2fa389f1?hl=ja