### PR TITLE
Task 6: Implement active filter display and individual filter removal functionality

### DIFF
--- a/frontend/src/components/ActiveFiltersDisplay.tsx
+++ b/frontend/src/components/ActiveFiltersDisplay.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { Box, Chip, Typography, Button } from "@mui/material";
+import { EmployeeFilters } from "../models/Employee";
+
+interface ActiveFiltersDisplayProps {
+  filters: EmployeeFilters;
+  onRemoveFilter: (
+    filterType: "minAge" | "maxAge" | "skills",
+    value?: string
+  ) => void;
+  onClearAll: () => void;
+}
+
+export function ActiveFiltersDisplay({
+  filters,
+  onRemoveFilter,
+  onClearAll,
+}: ActiveFiltersDisplayProps) {
+  // フィルター条件が何もない場合は表示しない
+  const hasFilters =
+    filters.minAge !== undefined ||
+    filters.maxAge !== undefined ||
+    (filters.skills && filters.skills.length > 0);
+
+  if (!hasFilters) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="body2" color="text.secondary">
+        📋 適用中のフィルター:
+      </Typography>
+      <Box
+        sx={{ display: "flex", flexWrap: "wrap", gap: 1, alignItems: "center" }}
+      >
+        {/* 年齢フィルター */}
+        {(filters.minAge !== undefined || filters.maxAge !== undefined) && (
+          <Chip
+            label={`年齢: ${filters.minAge ?? 18}-${filters.maxAge ?? 70}歳`}
+            onDelete={() => {
+              onRemoveFilter("minAge");
+              onRemoveFilter("maxAge");
+            }}
+            color="primary"
+            variant="outlined"
+          />
+        )}
+
+        {/* スキルフィルター */}
+        {filters.skills?.map((skill) => (
+          <Chip
+            key={skill}
+            label={skill}
+            onDelete={() => onRemoveFilter("skills", skill)}
+            color="secondary"
+            variant="outlined"
+          />
+        ))}
+
+        {/* すべてクリアボタン */}
+        <Button size="small" onClick={onClearAll} sx={{ ml: 1 }}>
+          すべてクリア
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/DetailedFilterModal.tsx
+++ b/frontend/src/components/DetailedFilterModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -38,6 +38,11 @@ export function DetailedFilterModal({
   const [selectedSkills, setSelectedSkills] = useState<string[]>(
     initialFilters.skills ?? []
   );
+
+  useEffect(() => {
+    setAgeRange([initialFilters.minAge ?? 20, initialFilters.maxAge ?? 60]);
+    setSelectedSkills(initialFilters.skills ?? []);
+  }, [initialFilters]);
 
   const handleAgeChange = (event: Event, newValue: number | number[]) => {
     setAgeRange(newValue as number[]);

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,9 +3,9 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 import React from "react";
-import { Breadcrumbs, Typography, Link as MuiLink } from "@mui/material";
+// import { Breadcrumbs, Typography, Link as MuiLink } from "@mui/material";
 import Link from "next/link";
-import HomeIcon from "@mui/icons-material/Home";
+// import HomeIcon from "@mui/icons-material/Home";
 
 interface BreadcrumbItem {
   label: string;

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -20,6 +20,7 @@ import { EmployeeListContainer } from "./EmployeeListContainer";
 import { type EmployeeListLayout } from "@/types/EmployeeListLayout";
 import { DetailedFilterModal } from "./DetailedFilterModal";
 import { EmployeeFilters } from "../models/Employee";
+import { ActiveFiltersDisplay } from "./ActiveFiltersDisplay";
 
 export function SearchEmployees() {
   const [searchKeyword, setSearchKeyword] = useState("");
@@ -32,6 +33,31 @@ export function SearchEmployees() {
 
   const handleApplyFilters = (filters: EmployeeFilters) => {
     setDetailedFilters(filters);
+  };
+
+  const handleRemoveFilter = (
+    filterType: "minAge" | "maxAge" | "skills",
+    value?: string
+  ) => {
+    const newFilters = { ...detailedFilters };
+
+    if (filterType === "minAge" || filterType === "maxAge") {
+      // 年齢フィルターを削除
+      delete newFilters.minAge;
+      delete newFilters.maxAge;
+    } else if (filterType === "skills" && value) {
+      // 特定のスキルを削除
+      newFilters.skills = newFilters.skills?.filter((skill) => skill !== value);
+      if (newFilters.skills?.length === 0) {
+        delete newFilters.skills;
+      }
+    }
+
+    setDetailedFilters(newFilters);
+  };
+
+  const handleClearAllFilters = () => {
+    setDetailedFilters({});
   };
 
   return (
@@ -61,6 +87,13 @@ export function SearchEmployees() {
             詳細検索
           </Button>
         </Box>
+
+        {/* 適用中のフィルタ表示*/}
+        <ActiveFiltersDisplay
+          filters={detailedFilters}
+          onRemoveFilter={handleRemoveFilter}
+          onClearAll={handleClearAllFilters}
+        />
         <Box display="flex" justifyContent="space-between" alignItems="center">
           {/* 並び替え用ドロップダウンを追加 */}
           <FormControl sx={{ minWidth: 200 }}>


### PR DESCRIPTION

## 📝 概要
詳細検索機能にフィルター条件の可視化と個別削除機能を実装しました。適用中のフィルター条件をチップ形式で表示し、ユーザーが直感的に条件を確認・削除できるようになり、検索体験が大幅に向上しました。

## 🔧 変更点

### フロントエンド
- `ActiveFiltersDisplay.tsx`: フィルター条件表示コンポーネントを新規作成
  - Material-UIのChipコンポーネントで年齢・スキル条件を可視化
  - 各条件に個別削除ボタン（❌）を配置
  - 「すべてクリア」ボタンで全条件一括削除
- `SearchEmployees.tsx`: ActiveFiltersDisplayコンポーネントを統合
  - フィルター個別削除ハンドラー（handleRemoveFilter）を実装
  - 全削除ハンドラー（handleClearAllFilters）を実装
  - 検索エリアと並び替えエリアの間に配置
- `DetailedFilterModal.tsx`: モーダル状態の同期を改善
  - useEffectでinitialFiltersの変更を監視
  - 外部でフィルターがクリアされた際にモーダル内部状態も自動リセット

### バックエンド
- `EmployeeDatabaseDynamoDB.ts`: 詳細フィルタリング機能を実装
  - getEmployeesFilteredメソッドを追加（AWS Lambda環境対応）
  - 名前・年齢・スキルによる複合フィルタリングロジック
  - DynamoDB ScanCommandでの全件取得後フィルタリング

## 💡 アピールポイント
- **直感的なUX**: 適用中の条件が一目で分かるチップ表示により、ユーザーの認知負荷を軽減
- **柔軟な操作性**: 個別削除と全削除の両方に対応し、細かい調整から全リセットまで自在に操作可能
- **状態同期の完全性**: メイン画面とモーダル間でフィルター状態が完全に同期し、一貫性のある体験を提供
- **拡張性重視の設計**: 新しいフィルター属性の追加時も既存パターンに従って容易に対応可能

## 🤖 生成 AI の利用
- 使用した
- 使用した場合は具体的な内容：
使用モデル：Claude Sonnet 4
使用方法：プロジェクト機能を使用。前提条件として本プロダクトのGitHubなどを読み込みを行った。
システムプロンプト：
```
#役割
貴方はプロのエンジニアです。私は修士1年の就活生で、これからインターンシップに参加します。
このインターンでは「タレントマネジメントシステム」の開発を行います。
サポートをお願いします。
```

本課題におけるやりとり：https://www.notion.so/Task-6-Implement-advanced-employee-filtering-functionality-20c5da4525c880558f86de89a189cdae?source=copy_link
このメッセージはいかがでしょうか？修正が必要な部分があれば教えてください！